### PR TITLE
Update to latest Minecraft version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,12 @@ $ ./clean.sh
 * libgeotiff
 
 ## Notes
-The following arguments are not yet implemented:
-* --ignoredblocks 
-* --blocks
+* Scans chunk block state data so ignored block rules (like stripping leaves and logs) work consistently across current Minecraft Java Edition releases with the expanded world height introduced in 1.18.
+* Legacy region files that rely on numeric block IDs are no longer supported.
+* DEMs are now exported using 16-bit samples to capture the full vertical range of modern worlds.
+* The following arguments are not yet implemented:
+  * --ignoredblocks
+  * --blocks
 
 ## Screenshots
 This enables you to make some things using standard GIS software, like some examples shown below.

--- a/src/constants.h
+++ b/src/constants.h
@@ -19,8 +19,12 @@
 #ifndef NIN_ANVIL_CONSTANTS_H
 #define NIN_ANVIL_CONSTANTS_H
 
+#include <stdint.h>
+
 #define REGION_HEIGHT 512
 #define REGION_WIDTH 512
 #define REGION_SIZE (REGION_WIDTH * REGION_HEIGHT)
+
+#define HEIGHT_UNSET INT16_MIN
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -80,18 +80,40 @@ West(-x)    +----+----+----+----+----+----+----+----+----+----+----+----+----+--
  * Row and column are always relative to their container.
  */
 
-static uint8_t forbidden_blocks[] = {0, 18, 161, 17, 162, 8, 9};
-static const size_t forbidden_blocks_size = sizeof(forbidden_blocks);
+static bool block_name_is(const char *block_name, const char *needle)
+{
+  return block_name != NULL && strcmp(block_name, needle) == 0;
+}
+
+static bool block_name_contains(const char *block_name, const char *needle)
+{
+  return block_name != NULL && strstr(block_name, needle) != NULL;
+}
 
 /*
  * Whether a block type should be ignored or not when calculating block column height
  * This is useful for example when you want to exclude leaves and logs (trees) from the resulting DEM.
  */
-static bool is_ground(uint8_t block_id)
+static bool is_ground(const char *block_name)
 {
-  for (size_t i = 0; i < forbidden_blocks_size; i++)
+  if(block_name != NULL)
   {
-    if(forbidden_blocks[i] == block_id) return false;
+    if(block_name_is(block_name, "minecraft:air") ||
+       block_name_is(block_name, "minecraft:void_air") ||
+       block_name_is(block_name, "minecraft:cave_air") ||
+       block_name_is(block_name, "minecraft:water") ||
+       block_name_is(block_name, "minecraft:flowing_water"))
+    {
+      return false;
+    }
+
+    if(block_name_contains(block_name, "leaves") ||
+       block_name_contains(block_name, "log") ||
+       block_name_contains(block_name, "stem") ||
+       block_name_contains(block_name, "hyphae"))
+    {
+      return false;
+    }
   }
   return true;
 }
@@ -226,11 +248,15 @@ int main(int argc, char *argv[])
 
 
   const size_t imgbuf_size = REGION_SIZE;
-  uint8_t *imgbuf = calloc(imgbuf_size, 1);
+  int16_t *imgbuf = malloc(imgbuf_size * sizeof(int16_t));
   if(imgbuf == NULL)
   {
     fprintf(stderr, "Could not allocate image buffer. (%s)", strerror(errno));
     exit(EXIT_FAILURE);
+  }
+  for(size_t i = 0; i < imgbuf_size; i++)
+  {
+    imgbuf[i] = HEIGHT_UNSET;
   }
 
   long long region_x;

--- a/src/maketif.c
+++ b/src/maketif.c
@@ -19,11 +19,14 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <stddef.h> // for size_t
+#include <stdio.h>
 #include <xtiffio.h>
 #include <geotiffio.h>
+#include <tiff.h>
 
 #include "utils.h"
 #include "conversions.h"
+#include "constants.h"
 
 // See https://stackoverflow.com/questions/24059421
 // And see https://www.asmail.be/msg0054699392.html
@@ -43,7 +46,7 @@ static void register_custom_tiff_tags(TIFF *tif) {
 // origin is left-top
 void maketif(
     const char *filepath,
-    const void *buf,
+    const int16_t *buf,
     const int compression,
     const long long buf_origin_cartesian_x,
     const long long buf_origin_cartesian_y,
@@ -111,7 +114,8 @@ void maketif(
   TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, width);
   TIFFSetField(tif, TIFFTAG_IMAGELENGTH, height);
   TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, 1);
-  TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, 8);
+  TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, 16);
+  TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_INT);
   TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, 1);
   TIFFSetField(tif, TIFFTAG_ORIENTATION, ORIENTATION_TOPLEFT);
   TIFFSetField(tif, TIFFTAG_COMPRESSION, compression);
@@ -132,7 +136,8 @@ void maketif(
 
     // tdata_t is TIFFalese for `typedef void* tdata_t`
     // IMPORTANT: TIFF 'row' seems to start at 0 instead of our 1, thus we subtract 1
-    if(TIFFWriteScanline(tif, (tdata_t) (buf + rowcol_to_index(row, mincol, buf_width)), tiffrow, 0) != 1)
+    const int16_t *rowptr = buf + rowcol_to_index(row, mincol, buf_width);
+    if(TIFFWriteScanline(tif, (tdata_t) rowptr, tiffrow, 0) != 1)
     {
       fprintf(stderr, "TIFFWriteScanLine returned an error.");
       exit(EXIT_FAILURE);
@@ -153,7 +158,9 @@ void maketif(
   GTIFFree(gtif);
 
   register_custom_tiff_tags(tif);
-  TIFFSetField(tif, TIFFTAG_GDAL_NODATA, "0"); // The number must be an ASCII string.
+  char nodata_buf[16];
+  snprintf(nodata_buf, sizeof(nodata_buf), "%d", HEIGHT_UNSET);
+  TIFFSetField(tif, TIFFTAG_GDAL_NODATA, nodata_buf); // The number must be an ASCII string.
 
   XTIFFClose(tif);
 }

--- a/src/maketif.h
+++ b/src/maketif.h
@@ -19,10 +19,12 @@
 #ifndef NIN_ANVIL_MAKETIF_H
 #define NIN_ANVIL_MAKETIF_H
 
+#include <stdint.h>
+
 
 void maketif(
     const char *filepath,
-    const void *buf,
+    const int16_t *buf,
     const int compression,
     const long long buf_origin_cartesian_x,
     const long long buf_origin_cartesian_y,

--- a/src/parseregion.c
+++ b/src/parseregion.c
@@ -22,13 +22,17 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <assert.h>
+#include <limits.h>
+#include <string.h>
 
 #include <arpa/inet.h>
 
 #include <nbt/nbt.h>
+#include <nbt/list.h>
 
 #include "utils.h"
 #include "parseregion.h"
+#include "constants.h"
 
 
 #define htonll(x) ((1==htonl(1)) ? (x) : ((uint64_t)htonl((x) & 0xFFFFFFFF) << 32) | htonl((x) >> 32))
@@ -57,6 +61,9 @@ static void handle_chunk(nbt_node *chunk,
     long long *min_cartesian_y,
     output_point_func_t output_point,
     void *output_point_aux);
+
+static void reset_current_chunk_heightmap(void);
+static void populate_section(nbt_node *section, int32_t section_y);
 
 static is_ground_func_t is_ground_func;
 
@@ -129,8 +136,196 @@ void parse_region(const uint8_t *buf, const size_t size,
 }
 
 // Variables used in handle_chunk and handle_section
-static uint8_t current_chunk_heightmap[256];
-static int8_t last_section_y = -1;
+static int16_t current_chunk_heightmap[256];
+static int32_t last_section_y = INT32_MIN;
+
+static void reset_current_chunk_heightmap(void)
+{
+  for(size_t i = 0; i < 256; i++)
+  {
+    current_chunk_heightmap[i] = HEIGHT_UNSET;
+  }
+  last_section_y = INT32_MIN;
+}
+
+static void populate_section(nbt_node *section, int32_t section_y)
+{
+  nbt_node *palette_node = NULL;
+  nbt_node *data_node = NULL;
+
+  nbt_node *block_states_container = nbt_find_by_name(section, "block_states");
+  if(block_states_container != NULL)
+  {
+    if(block_states_container->type != TAG_COMPOUND)
+    {
+      fprintf(stderr, "'block_states' tag in chunk section is not of type TAG_COMPOUND.\n");
+      exit(EXIT_FAILURE);
+    }
+    palette_node = nbt_find_by_name(block_states_container, "palette");
+    data_node = nbt_find_by_name(block_states_container, "data");
+  }
+  else
+  {
+    palette_node = nbt_find_by_name(section, "Palette");
+    data_node = nbt_find_by_name(section, "BlockStates");
+  }
+
+  if(palette_node == NULL)
+  {
+    fprintf(stderr, "Chunk section is missing a block state palette.\n");
+    exit(EXIT_FAILURE);
+  }
+
+  if(palette_node->type != TAG_LIST)
+  {
+    fprintf(stderr, "'Palette' tag in chunk section is not of type TAG_LIST.\n");
+    exit(EXIT_FAILURE);
+  }
+
+  struct nbt_list *palette_list = palette_node->payload.tag_list;
+  if(palette_list == NULL)
+  {
+    fprintf(stderr, "Block state palette is empty.\n");
+    exit(EXIT_FAILURE);
+  }
+
+  size_t palette_size = 0;
+  const struct list_head *pos;
+  list_for_each(pos, &palette_list->entry)
+  {
+    const struct nbt_list *entry = list_entry(pos, const struct nbt_list, entry);
+    if(entry->data == NULL)
+      continue;
+    if(entry->data->type != TAG_COMPOUND)
+    {
+      fprintf(stderr, "Palette entry is not of type TAG_COMPOUND.\n");
+      exit(EXIT_FAILURE);
+    }
+    palette_size++;
+  }
+
+  if(palette_size == 0)
+  {
+    fprintf(stderr, "Block state palette does not contain any entries.\n");
+    exit(EXIT_FAILURE);
+  }
+
+  const char **palette_names = malloc(sizeof(char *) * palette_size);
+  if(palette_names == NULL)
+  {
+    fprintf(stderr, "Out of memory while allocating palette name array.\n");
+    exit(EXIT_FAILURE);
+  }
+
+  size_t palette_index = 0;
+  list_for_each(pos, &palette_list->entry)
+  {
+    const struct nbt_list *entry = list_entry(pos, const struct nbt_list, entry);
+    if(entry->data == NULL)
+      continue;
+
+    nbt_node *name_node = nbt_find_by_name(entry->data, "Name");
+    if(name_node == NULL)
+    {
+      fprintf(stderr, "Palette entry is missing 'Name' tag.\n");
+      exit(EXIT_FAILURE);
+    }
+    if(name_node->type != TAG_STRING)
+    {
+      fprintf(stderr, "Palette entry 'Name' tag is not of type TAG_STRING.\n");
+      exit(EXIT_FAILURE);
+    }
+
+    palette_names[palette_index++] = name_node->payload.tag_string.data;
+  }
+
+  if(palette_index != palette_size)
+  {
+    fprintf(stderr, "Palette enumeration mismatch.\n");
+    exit(EXIT_FAILURE);
+  }
+
+  size_t bits_per_entry = 1;
+  while((1ULL << bits_per_entry) < palette_size)
+  {
+    bits_per_entry++;
+  }
+  if(bits_per_entry < 4 && palette_size > 1)
+    bits_per_entry = 4;
+
+  uint64_t mask = (bits_per_entry >= 64) ? UINT64_MAX : ((1ULL << bits_per_entry) - 1ULL);
+
+  const int64_t *data = NULL;
+  size_t data_length = 0;
+  if(data_node != NULL)
+  {
+    if(data_node->type != TAG_LONG_ARRAY)
+    {
+      fprintf(stderr, "'BlockStates' data is not of type TAG_LONG_ARRAY.\n");
+      exit(EXIT_FAILURE);
+    }
+    const struct nbt_long_array *array = &data_node->payload.tag_long_array;
+    data = array->data;
+    data_length = (size_t) array->length;
+  }
+
+  for(int y = 15; y >= 0; y--)
+  {
+    int32_t current_y = section_y * 16 + y;
+    if(current_y > INT16_MAX)
+      current_y = INT16_MAX;
+    else if(current_y < INT16_MIN)
+      current_y = INT16_MIN;
+
+    for(uint_fast16_t j = 0; j < 256; j++)
+    {
+      size_t block_index = (size_t) y * 256 + j;
+      uint64_t palette_value = 0;
+
+      if(data_length > 0)
+      {
+        size_t bit_index = block_index * bits_per_entry;
+        size_t long_index = bit_index / 64;
+        size_t bit_offset = bit_index % 64;
+
+        if(long_index >= data_length)
+        {
+          fprintf(stderr, "BlockStates array does not contain enough data.\n");
+          exit(EXIT_FAILURE);
+        }
+
+        uint64_t value = (uint64_t) data[long_index] >> bit_offset;
+        size_t bits_read = 64 - bit_offset;
+        if(bits_read < bits_per_entry)
+        {
+          if(long_index + 1 >= data_length)
+          {
+            fprintf(stderr, "BlockStates array does not contain enough data.\n");
+            exit(EXIT_FAILURE);
+          }
+          value |= (uint64_t) data[long_index + 1] << bits_read;
+        }
+
+        palette_value = value & mask;
+      }
+
+      if(palette_value >= palette_size)
+      {
+        fprintf(stderr, "Palette index out of range.\n");
+        exit(EXIT_FAILURE);
+      }
+
+      const char *block_name = palette_names[palette_value];
+
+      if(is_ground_func(block_name) && current_chunk_heightmap[j] < current_y)
+      {
+        current_chunk_heightmap[j] = (int16_t) current_y;
+      }
+    }
+  }
+
+  free(palette_names);
+}
 
 static void handle_chunk(nbt_node *chunk,
     long long *max_cartesian_x,
@@ -194,6 +389,7 @@ static void handle_chunk(nbt_node *chunk,
     exit(EXIT_FAILURE);
   }
 
+  reset_current_chunk_heightmap();
   nbt_map(sections, handle_section, NULL);
 
   for(size_t i = 0; i < 256; i++)
@@ -217,9 +413,7 @@ static void handle_chunk(nbt_node *chunk,
   if(new_max_cartesian_y > *max_cartesian_y) *max_cartesian_y = new_max_cartesian_y;
   if(new_min_cartesian_y < *min_cartesian_y) *min_cartesian_y = new_min_cartesian_y;
 
-  // Reset current chunk heightmap
-  memset(current_chunk_heightmap, 0, 256);
-  last_section_y = -1;
+  reset_current_chunk_heightmap();
 }
 
 
@@ -235,12 +429,16 @@ static bool handle_section(nbt_node *section, unused_ void *aux)
     fprintf(stderr, "Could not find 'Y' tag in chunk section.\n");
     exit(EXIT_FAILURE);
   }
-  if(section_y_nbt->type != TAG_BYTE)
+  int32_t section_y;
+  if(section_y_nbt->type == TAG_BYTE)
+    section_y = section_y_nbt->payload.tag_byte;
+  else if(section_y_nbt->type == TAG_INT)
+    section_y = section_y_nbt->payload.tag_int;
+  else
   {
-    fprintf(stderr, "'Y' tag in chunk section is not of type TAG_BYTE.\n");
+    fprintf(stderr, "'Y' tag in chunk section is not of a supported numeric type.\n");
     exit(EXIT_FAILURE);
   }
-  int8_t section_y = section_y_nbt->payload.tag_byte;
   if(section_y <= last_section_y)
   {
     return true;
@@ -249,34 +447,6 @@ static bool handle_section(nbt_node *section, unused_ void *aux)
   {
     last_section_y = section_y;
   }
-  nbt_node *blocks = nbt_find_by_name(section, "Blocks");
-  if(blocks == NULL)
-  {
-    fprintf(stderr, "Could not find 'Blocks' tag in chunk section.\n");
-    exit(EXIT_FAILURE);
-  }
-  else if(blocks->type != TAG_BYTE_ARRAY)
-  {
-    fprintf(stderr, "'Blocks' tag in chunk section is not of type TAG_BYTE_ARRAY.\n");
-    exit(EXIT_FAILURE);
-  }
-  else if(blocks->payload.tag_byte_array.length != 4096)
-  {
-    fprintf(stderr, "'Blocks' byte array length is not 4096.\n");
-    exit(EXIT_FAILURE);
-  }
-  for(int y = 15; y >= 0; y--)
-  {
-    uint_fast8_t current_y = section_y * 16 + y;
-    for(uint_fast16_t j = 0; j < 256; j++)
-    {
-      uint8_t current_block_id = (uint8_t) blocks->payload.tag_byte_array.data[y * 256 + j];
-
-      if(is_ground_func(current_block_id) && current_chunk_heightmap[j] < current_y)
-      {
-        current_chunk_heightmap[j] = current_y;
-      }
-    }
-  }
+  populate_section(section, section_y);
   return true;
 }

--- a/src/parseregion.h
+++ b/src/parseregion.h
@@ -24,14 +24,16 @@
 #include <stdbool.h>
 
 
-typedef void (*output_point_func_t)(long long cartesian_x, long long cartesian_y, uint8_t height, void *aux);
+typedef void (*output_point_func_t)(long long cartesian_x, long long cartesian_y, int16_t height, void *aux);
 
 
 /*
- * Whether a block type should be ignored or not when calculating block column height
- * This is useful for example when you want to exclude leaves and logs (trees) from the resulting DEM.
+ * Whether a block type should be ignored or not when calculating block column height.
+ *
+ * Modern Minecraft chunks encode blocks using palette names instead of legacy numeric
+ * identifiers, so we only expose the resolved block name when evaluating filters.
  */
-typedef bool (*is_ground_func_t)(uint8_t block_id);
+typedef bool (*is_ground_func_t)(const char *block_name);
 
 
 // buf size should be at least 4096.

--- a/src/parsingutils.c
+++ b/src/parsingutils.c
@@ -34,7 +34,7 @@
 
 struct auxdata
 {
-  uint8_t *outbuf;
+  int16_t *outbuf;
   size_t size;
 };
 
@@ -46,12 +46,12 @@ struct auxdata
  *
  * This function assumes outbuf has the dimensions of Minecraft region, 512x512, one byte per block column.
  */
-void output_point_func(long long x, long long y, uint8_t height, void *aux)
+void output_point_func(long long x, long long y, int16_t height, void *aux)
 {
   assert(aux != NULL);
 
   struct auxdata *auxd = (struct auxdata *) aux;
-  uint8_t *outbuf = auxd->outbuf;
+  int16_t *outbuf = auxd->outbuf;
   size_t size = auxd->size;
 
   assert(outbuf != NULL);
@@ -81,7 +81,7 @@ void output_point_func(long long x, long long y, uint8_t height, void *aux)
   // Zero is technically a valid existing value, but a really rare one in typical worlds.
   // If the value is not zero we know for sure we're overwriting an existing value
   // If the value is zero we are unsure whether we are overwriting an existing value or not.
-  assert(outbuf[index] == 0);
+  assert(outbuf[index] == HEIGHT_UNSET);
 
   outbuf[index] = height;
 }
@@ -89,7 +89,7 @@ void output_point_func(long long x, long long y, uint8_t height, void *aux)
 /*
  * outbuf must be at least of size REGION_SIZE.
  */
-void region2dem(uint8_t *outbuf, const uint8_t *inbuf, size_t inbuf_size, is_ground_func_t is_ground_func,
+void region2dem(int16_t *outbuf, const uint8_t *inbuf, size_t inbuf_size, is_ground_func_t is_ground_func,
     long long *out_region_x,
     long long *out_region_y)
 {
@@ -124,7 +124,7 @@ void region2dem(uint8_t *outbuf, const uint8_t *inbuf, size_t inbuf_size, is_gro
 #define BUF_SIZE 52428800ULL
 static uint8_t buf[BUF_SIZE];
 
-void regionfile2dem(uint8_t *outbuf, const char *filepath, is_ground_func_t is_ground_func,
+void regionfile2dem(int16_t *outbuf, const char *filepath, is_ground_func_t is_ground_func,
     long long *out_region_x,
     long long *out_region_y)
 {

--- a/src/parsingutils.h
+++ b/src/parsingutils.h
@@ -25,11 +25,11 @@
 #include "parseregion.h" // for is_ground_func_t
 
 
-//void region2dem(uint8_t *outbuf, const uint8_t *inbuf, size_t size, is_ground_func_t is_ground_func,
+//void region2dem(int16_t *outbuf, const uint8_t *inbuf, size_t size, is_ground_func_t is_ground_func,
     //long long *out_cartesian_region_x,
     //long long *out_cartesian_region_y);
 
-void regionfile2dem(uint8_t *outbuf, const char *filepath, is_ground_func_t is_ground_func,
+void regionfile2dem(int16_t *outbuf, const char *filepath, is_ground_func_t is_ground_func,
     long long *out_cartesian_region_x,
     long long*out_cartesian_region_y);
 


### PR DESCRIPTION
## Summary
- require chunk sections to provide block state palettes and remove the numeric Blocks fallback when populating heights
- simplify the ground filter to operate solely on palette names and update the callback signature accordingly
- document that region files depending on legacy numeric block IDs are no longer supported

## Testing
- ./build.sh *(fails: missing xtiffio.h header in build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9570ea8bc8322b168788c76bd76ab